### PR TITLE
Add manager_service_restart parameter

### DIFF
--- a/playbooks/manager.yml
+++ b/playbooks/manager.yml
@@ -13,9 +13,13 @@
 - name: Restart manager service
   hosts: manager
 
+  vars:
+    manager_service_restart: true
+
   tasks:
     - name: Restart manager service
       become: true
       ansible.builtin.service:
         name: docker-compose@manager
         state: restarted
+      when: manager_service_restart|bool


### PR DESCRIPTION
Controls the behavior of the manager restart. If set to false the manager service will not restart.