### PR TITLE
Gather facts in the configuration play

### DIFF
--- a/playbooks/configuration.yml
+++ b/playbooks/configuration.yml
@@ -3,7 +3,6 @@
 
 - name: Update configuration
   hosts: manager
-  gather_facts: false
 
   roles:
     - role: osism.commons.configuration


### PR DESCRIPTION
Required now because we check the ansible_os_family fact in the install required packages task and we do not have the facts cache when seeding the manager.